### PR TITLE
feat: classify conversation facts vs evaluations

### DIFF
--- a/src/features/common/config/schema.js
+++ b/src/features/common/config/schema.js
@@ -30,6 +30,7 @@ const LATEST_SCHEMA = {
             { name: 'speaker', type: 'TEXT' },
             { name: 'text', type: 'TEXT' },
             { name: 'lang', type: 'TEXT' },
+            { name: 'nvc_type', type: 'TEXT' },
             { name: 'created_at', type: 'INTEGER' },
             { name: 'sync_state', type: 'TEXT DEFAULT \'clean\'' }
         ]

--- a/src/features/common/prompts/promptTemplates.js
+++ b/src/features/common/prompts/promptTemplates.js
@@ -1,3 +1,5 @@
+const CLASSIFICATION_PROMPT = `You are an assistant that classifies dialogue lines according to Nonviolent Communication principles. Each line should be labeled as either an "observation" (objective fact) or an "evaluation" (judgment or interpretation). Respond strictly in JSON with a "transcripts" array containing objects {"id": string, "nvc_type": "observation"|"evaluation"}. Also include top level "observations" and "evaluations" arrays listing the text of each line classified.`;
+
 const profilePrompts = {
     interview: {
         intro: `You are the user's live-meeting co-pilot called Pickle, developed and created by Pickle. Prioritize only the most recent context from the conversation.`,
@@ -402,8 +404,10 @@ Provide only the exact words to say in **markdown format**. Focus on finding win
         outputInstructions: `{{CONVERSATION_HISTORY}}`,
     },
 
+    nvc_fact_eval: CLASSIFICATION_PROMPT,
 };
 
 module.exports = {
     profilePrompts,
+    CLASSIFICATION_PROMPT,
 };

--- a/src/features/common/services/migrationService.js
+++ b/src/features/common/services/migrationService.js
@@ -108,6 +108,7 @@ async function checkAndRunMigration(firebaseUser) {
                     speaker: t.speaker ?? null,
                     text: encryptionService.encrypt(t.text ?? ''),
                     lang: t.lang ?? 'en',
+                    nvc_type: t.nvc_type ?? null,
                     created_at: t.created_at ? Timestamp.fromMillis(t.created_at * 1000) : null
                 };
                 phase2Batch.set(transcriptRef, cleanTranscript);

--- a/src/features/listen/stt/repositories/firebase.repository.js
+++ b/src/features/listen/stt/repositories/firebase.repository.js
@@ -1,4 +1,13 @@
-const { collection, addDoc, query, getDocs, orderBy, Timestamp } = require('firebase/firestore');
+const {
+    collection,
+    addDoc,
+    query,
+    getDocs,
+    orderBy,
+    Timestamp,
+    doc,
+    updateDoc,
+} = require('firebase/firestore');
 const { getFirestoreInstance } = require('../../../common/services/firebaseClient');
 const { createEncryptedConverter } = require('../../../common/repositories/firestoreConverter');
 
@@ -30,9 +39,9 @@ async function getAllTranscriptsBySessionId(sessionId) {
     return querySnapshot.docs.map(doc => doc.data());
 }
 
-async function updateTranscriptType(id, nvc_type) {
-    // Firestore update implementation can be added later
-    return Promise.resolve();
+async function updateTranscriptType(sessionId, id, nvc_type) {
+    const transcriptRef = doc(getFirestoreInstance(), `sessions/${sessionId}/transcripts`, id);
+    await updateDoc(transcriptRef, { nvc_type });
 }
 
 module.exports = {
@@ -40,3 +49,4 @@ module.exports = {
     getAllTranscriptsBySessionId,
     updateTranscriptType,
 };
+

--- a/src/features/listen/stt/repositories/firebase.repository.js
+++ b/src/features/listen/stt/repositories/firebase.repository.js
@@ -30,7 +30,13 @@ async function getAllTranscriptsBySessionId(sessionId) {
     return querySnapshot.docs.map(doc => doc.data());
 }
 
+async function updateTranscriptType(id, nvc_type) {
+    // Firestore update implementation can be added later
+    return Promise.resolve();
+}
+
 module.exports = {
     addTranscript,
     getAllTranscriptsBySessionId,
-}; 
+    updateTranscriptType,
+};

--- a/src/features/listen/stt/repositories/index.js
+++ b/src/features/listen/stt/repositories/index.js
@@ -17,6 +17,9 @@ const sttRepositoryAdapter = {
     },
     getAllTranscriptsBySessionId: (sessionId) => {
         return getBaseRepository().getAllTranscriptsBySessionId(sessionId);
+    },
+    updateTranscriptType: (id, nvc_type) => {
+        return getBaseRepository().updateTranscriptType(id, nvc_type);
     }
 };
 

--- a/src/features/listen/stt/repositories/index.js
+++ b/src/features/listen/stt/repositories/index.js
@@ -18,9 +18,9 @@ const sttRepositoryAdapter = {
     getAllTranscriptsBySessionId: (sessionId) => {
         return getBaseRepository().getAllTranscriptsBySessionId(sessionId);
     },
-    updateTranscriptType: (id, nvc_type) => {
-        return getBaseRepository().updateTranscriptType(id, nvc_type);
+    updateTranscriptType: (sessionId, id, nvc_type) => {
+        return getBaseRepository().updateTranscriptType(sessionId, id, nvc_type);
     }
 };
 
-module.exports = sttRepositoryAdapter; 
+module.exports = sttRepositoryAdapter;

--- a/src/features/listen/stt/repositories/sqlite.repository.js
+++ b/src/features/listen/stt/repositories/sqlite.repository.js
@@ -22,7 +22,20 @@ function getAllTranscriptsBySessionId(sessionId) {
     return db.prepare(query).all(sessionId);
 }
 
+function updateTranscriptType(id, nvc_type) {
+    const db = sqliteClient.getDb();
+    const query = "UPDATE transcripts SET nvc_type = ? WHERE id = ?";
+
+    try {
+        db.prepare(query).run(nvc_type, id);
+    } catch (err) {
+        console.error('Error updating transcript type:', err);
+        throw err;
+    }
+}
+
 module.exports = {
     addTranscript,
     getAllTranscriptsBySessionId,
-}; 
+    updateTranscriptType,
+};

--- a/src/features/listen/stt/repositories/sqlite.repository.js
+++ b/src/features/listen/stt/repositories/sqlite.repository.js
@@ -22,7 +22,7 @@ function getAllTranscriptsBySessionId(sessionId) {
     return db.prepare(query).all(sessionId);
 }
 
-function updateTranscriptType(id, nvc_type) {
+function updateTranscriptType(sessionId, id, nvc_type) {
     const db = sqliteClient.getDb();
     const query = "UPDATE transcripts SET nvc_type = ? WHERE id = ?";
 
@@ -39,3 +39,4 @@ module.exports = {
     getAllTranscriptsBySessionId,
     updateTranscriptType,
 };
+

--- a/src/features/listen/summary/summaryService.js
+++ b/src/features/listen/summary/summaryService.js
@@ -359,7 +359,11 @@ Keep all points concise and build upon previous analysis if provided.`,
                 }
 
                 try {
-                    sttRepository.updateTranscriptType(target.id, target.nvc_type);
+                    sttRepository.updateTranscriptType(
+                        target.session_id,
+                        target.id,
+                        target.nvc_type
+                    );
                 } catch (err) {
                     console.error('Error updating transcript type:', err);
                 }

--- a/src/ui/listen/summary/SummaryView.js
+++ b/src/ui/listen/summary/SummaryView.js
@@ -222,6 +222,14 @@ export class SummaryView extends LitElement {
             color: #f1fa8c;
         }
 
+        .observation {
+            background: rgba(80, 250, 123, 0.2);
+        }
+
+        .evaluation {
+            background: rgba(255, 121, 198, 0.2);
+        }
+
         .empty-state {
             display: flex;
             align-items: center;
@@ -246,6 +254,8 @@ export class SummaryView extends LitElement {
             topic: { header: '', bullets: [] },
             actions: [],
             followUps: [],
+            observations: [],
+            evaluations: [],
         };
         this.isVisible = true;
         this.hasCompletedRecording = false;
@@ -284,6 +294,8 @@ export class SummaryView extends LitElement {
             topic: { header: '', bullets: [] },
             actions: [],
             followUps: [],
+            observations: [],
+            evaluations: [],
         };
         this.requestUpdate();
     }
@@ -484,6 +496,40 @@ export class SummaryView extends LitElement {
                                       `
                                   )
                             : html` <div class="request-item">No content yet...</div> `}
+                        ${data.observations && data.observations.length > 0
+                            ? html`
+                                  <insights-title>Facts</insights-title>
+                                  ${data.observations.map(
+                                      (fact, index) => html`
+                                          <div
+                                              class="markdown-content observation"
+                                              data-markdown-id="observation-${index}"
+                                              data-original-text="${fact}"
+                                              @click=${() => this.handleMarkdownClick(fact)}
+                                          >
+                                              ${fact}
+                                          </div>
+                                      `
+                                  )}
+                              `
+                            : ''}
+                        ${data.evaluations && data.evaluations.length > 0
+                            ? html`
+                                  <insights-title>Evaluations</insights-title>
+                                  ${data.evaluations.map(
+                                      (evaluation, index) => html`
+                                          <div
+                                              class="markdown-content evaluation"
+                                              data-markdown-id="evaluation-${index}"
+                                              data-original-text="${evaluation}"
+                                              @click=${() => this.handleMarkdownClick(evaluation)}
+                                          >
+                                              ${evaluation}
+                                          </div>
+                                      `
+                                  )}
+                              `
+                            : ''}
                         ${data.topic.header
                             ? html`
                                   <insights-title>${data.topic.header}</insights-title>


### PR DESCRIPTION
## Summary
- add NVC fact/evaluation classification prompt and profile
- classify recent transcripts, persist nvc_type, and expose results
- render facts and evaluations lists with visual highlighting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b107aed88329969f45b5d48d9ca6