### PR TITLE
feat: include emotions in summary view

### DIFF
--- a/src/features/listen/summary/summaryService.js
+++ b/src/features/listen/summary/summaryService.js
@@ -192,12 +192,16 @@ Keep all points concise and build upon previous analysis if provided.`,
             topic: { header: '', bullets: [] },
             actions: [],
             followUps: ['✉️ Draft a follow-up email', '✅ Generate action items', '📝 Show summary'],
+            emotions: {},
         };
 
         // 이전 결과가 있으면 기본값으로 사용
         if (previousResult) {
             structuredData.topic.header = previousResult.topic.header;
             structuredData.summary = [...previousResult.summary];
+            if (previousResult.emotions) {
+                structuredData.emotions = { ...previousResult.emotions };
+            }
         }
 
         try {
@@ -226,6 +230,9 @@ Keep all points concise and build upon previous analysis if provided.`,
                     continue;
                 } else if (trimmedLine.startsWith('**Suggested Questions**')) {
                     currentSection = 'questions';
+                    continue;
+                } else if (trimmedLine.startsWith('**Emotions**')) {
+                    currentSection = 'emotions';
                     continue;
                 }
 
@@ -261,6 +268,14 @@ Keep all points concise and build upon previous analysis if provided.`,
                     if (question && question.includes('?')) {
                         structuredData.actions.push(`❓ ${question}`);
                     }
+                } else if (currentSection === 'emotions' && trimmedLine) {
+                    const lineContent = trimmedLine.startsWith('-')
+                        ? trimmedLine.substring(1).trim()
+                        : trimmedLine;
+                    const [speaker, feeling] = lineContent.split(':').map(s => s.trim());
+                    if (speaker && feeling) {
+                        structuredData.emotions[speaker] = feeling;
+                    }
                 }
             }
 
@@ -282,6 +297,9 @@ Keep all points concise and build upon previous analysis if provided.`,
             if (structuredData.topic.bullets.length === 0 && previousResult) {
                 structuredData.topic.bullets = previousResult.topic.bullets;
             }
+            if (Object.keys(structuredData.emotions).length === 0 && previousResult && previousResult.emotions) {
+                structuredData.emotions = previousResult.emotions;
+            }
         } catch (error) {
             console.error('❌ Error parsing response text:', error);
             // 에러 시 이전 결과 반환
@@ -291,6 +309,7 @@ Keep all points concise and build upon previous analysis if provided.`,
                     topic: { header: 'Analysis in progress', bullets: [] },
                     actions: ['✨ What should I say next?', '💬 Suggest follow-up questions'],
                     followUps: ['✉️ Draft a follow-up email', '✅ Generate action items', '📝 Show summary'],
+                    emotions: {},
                 }
             );
         }

--- a/src/ui/listen/summary/SummaryView.js
+++ b/src/ui/listen/summary/SummaryView.js
@@ -246,6 +246,7 @@ export class SummaryView extends LitElement {
             topic: { header: '', bullets: [] },
             actions: [],
             followUps: [],
+            emotions: {},
         };
         this.isVisible = true;
         this.hasCompletedRecording = false;
@@ -284,6 +285,7 @@ export class SummaryView extends LitElement {
             topic: { header: '', bullets: [] },
             actions: [],
             followUps: [],
+            emotions: {},
         };
         this.requestUpdate();
     }
@@ -422,7 +424,13 @@ export class SummaryView extends LitElement {
     }
 
     getSummaryText() {
-        const data = this.structuredData || { summary: [], topic: { header: '', bullets: [] }, actions: [] };
+        const data = this.structuredData || {
+            summary: [],
+            topic: { header: '', bullets: [] },
+            actions: [],
+            followUps: [],
+            emotions: {},
+        };
         let sections = [];
 
         if (data.summary && data.summary.length > 0) {
@@ -435,6 +443,12 @@ export class SummaryView extends LitElement {
 
         if (data.actions && data.actions.length > 0) {
             sections.push(`\nActions:\n${data.actions.map(a => `▸ ${a}`).join('\n')}`);
+        }
+
+        if (data.emotions && Object.keys(data.emotions).length > 0) {
+            sections.push(`\nEmotions:\n${Object.entries(data.emotions)
+                .map(([speaker, feeling]) => `${speaker}: ${feeling}`)
+                .join('\n')}`);
         }
 
         if (data.followUps && data.followUps.length > 0) {
@@ -458,9 +472,15 @@ export class SummaryView extends LitElement {
             summary: [],
             topic: { header: '', bullets: [] },
             actions: [],
+            followUps: [],
+            emotions: {},
         };
 
-        const hasAnyContent = data.summary.length > 0 || data.topic.bullets.length > 0 || data.actions.length > 0;
+        const hasAnyContent =
+            data.summary.length > 0 ||
+            data.topic.bullets.length > 0 ||
+            data.actions.length > 0 ||
+            (data.emotions && Object.keys(data.emotions).length > 0);
 
         return html`
             <div class="insights-container">
@@ -520,6 +540,24 @@ export class SummaryView extends LitElement {
                                               </div>
                                           `
                                       )}
+                              `
+                            : ''}
+                        ${data.emotions && Object.keys(data.emotions).length
+                            ? html`
+                                  <insights-title>Emotions</insights-title>
+                                  ${Object.entries(data.emotions).map(
+                                      ([speaker, feeling], idx) => html`
+                                          <div
+                                              class="markdown-content"
+                                              data-markdown-id="emotion-${idx}"
+                                              data-original-text="${speaker}: ${feeling}"
+                                              @click=${() =>
+                                                  this.handleMarkdownClick(`${speaker}: ${feeling}`)}
+                                          >
+                                              ${speaker}: ${feeling}
+                                          </div>
+                                      `
+                                  )}
                               `
                             : ''}
                         ${this.hasCompletedRecording && data.followUps && data.followUps.length > 0


### PR DESCRIPTION
## Summary
- extend summary structured data with `emotions` map and render dedicated section in SummaryView
- reset and summary text generation now handle emotional insights
- summary service parses `Emotions` section and forwards it via `summary-update` IPC messages

## Testing
- ⚠️ `npm run lint` *(missing eslint.config.js: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f5fff994832989ba49da768928bd