### PR TITLE
Add NVC emotion lists

### DIFF
--- a/src/features/listen/empathy/nvcEmotions.js
+++ b/src/features/listen/empathy/nvcEmotions.js
@@ -1,0 +1,36 @@
+/**
+ * Emotion categories derived from the Nonviolent Communication (NVC) feelings inventory.
+ * All emotion names are provided in UPPERCASE.
+ * @type {{SATISFIED: string[], NOT_SATISFIED: string[]}}
+ */
+module.exports = {
+    SATISFIED: [
+        'AFFECTIONATE',
+        'ENGAGED',
+        'HOPEFUL',
+        'CONFIDENT',
+        'EXCITED',
+        'GRATEFUL',
+        'INSPIRED',
+        'JOYFUL',
+        'EXHILARATED',
+        'PEACEFUL',
+        'REFRESHED'
+    ],
+    NOT_SATISFIED: [
+        'AFRAID',
+        'AVERSION',
+        'CONFUSED',
+        'ANNOYED',
+        'DISCONNECTED',
+        'ANGRY',
+        'VULNERABLE',
+        'YEARNING',
+        'DISQUIET',
+        'EMBARRASSED',
+        'FATIGUE',
+        'PAIN',
+        'SAD',
+        'TENSE'
+    ]
+};


### PR DESCRIPTION
## Summary
- Add NVC-derived emotion categories for satisfied and not satisfied states

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a5f604250883299f877e8a152167e9